### PR TITLE
Include libp2p into meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,8 @@ project('BestSource', 'cpp',
   meson_version : '>=0.48.0'
 )
 
+libs = []
+
 sources = [
   'src/audiosource.cpp',
   'src/audiosource.h',
@@ -14,6 +16,29 @@ sources = [
   'src/BSRational.h',
   'src/vapoursynth.cpp'
 ]
+
+libs += static_library('p2p_main',
+    [
+        'libp2p/p2p_api.cpp',
+        'libp2p/v210.cpp',
+        'libp2p/simd/cpuinfo_x86.cpp',
+        'libp2p/simd/p2p_simd.cpp'
+    ],
+    include_directories: ['libp2p', 'libp2p/simd'],
+    cpp_args: ['-std=c++14']
+)
+
+if host_machine.cpu_family().startswith('x86')
+    libs += static_library('p2p_sse41',
+        'libp2p/simd/p2p_sse41.cpp',
+        include_directories: ['libp2p', 'libp2p/simd'],
+        cpp_args: [
+          '-std=c++14',
+          '-DP2P_SIMD',
+          '-msse4.1'
+        ]
+    )
+endif
 
 vapoursynth_dep = dependency('vapoursynth', version: '>=R55').partial_dependency(compile_args: true, includes: true)
 jansson_dep = dependency('jansson', version: '>= 2.7', required: true)
@@ -27,6 +52,7 @@ deps = [
 
 shared_module('bestsource', sources,
   dependencies : deps,
+  link_with: libs,
   install : true,
   install_dir : join_paths(vapoursynth_dep.get_pkgconfig_variable('libdir'), 'vapoursynth'),
   gnu_symbol_visibility : 'hidden'


### PR DESCRIPTION
I forgot to actually add it, since H264@8-bit source with CPU decoding worked fine for me yesterday. 
Now with HW decoding libp2p is required, hence PR arranged.