### PR TITLE
meson: Fix libp2p compilation on x86

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,21 +1,23 @@
 project('BestSource', 'cpp',
-  default_options : ['buildtype=release', 'b_ndebug=if-release', 'cpp_std=c++14'],
-  meson_version : '>=0.48.0'
+    default_options: ['buildtype=release', 'b_ndebug=if-release', 'cpp_std=c++14'],
+    meson_version: '>=0.48.0'
 )
 
 libs = []
 
 sources = [
-  'src/audiosource.cpp',
-  'src/audiosource.h',
-  'src/videosource.cpp',
-  'src/videosource.h',
-  'src/SrcAttribCache.cpp',
-  'src/SrcAttribCache.h',
-  'src/BSRational.cpp',
-  'src/BSRational.h',
-  'src/vapoursynth.cpp'
+    'src/audiosource.cpp',
+    'src/videosource.cpp',
+    'src/SrcAttribCache.cpp',
+    'src/BSRational.cpp',
+    'src/vapoursynth.cpp'
 ]
+
+p2p_args = []
+
+if host_machine.cpu_family().startswith('x86')
+    p2p_args += ['-DP2P_SIMD']
+endif
 
 libs += static_library('p2p_main',
     [
@@ -25,18 +27,16 @@ libs += static_library('p2p_main',
         'libp2p/simd/p2p_simd.cpp'
     ],
     include_directories: ['libp2p', 'libp2p/simd'],
-    cpp_args: ['-std=c++14']
+    cpp_args: p2p_args
 )
 
 if host_machine.cpu_family().startswith('x86')
+    p2p_args += ['-msse4.1']
+
     libs += static_library('p2p_sse41',
         'libp2p/simd/p2p_sse41.cpp',
         include_directories: ['libp2p', 'libp2p/simd'],
-        cpp_args: [
-          '-std=c++14',
-          '-DP2P_SIMD',
-          '-msse4.1'
-        ]
+        cpp_args: p2p_args
     )
 endif
 
@@ -44,16 +44,16 @@ vapoursynth_dep = dependency('vapoursynth', version: '>=R55').partial_dependency
 jansson_dep = dependency('jansson', version: '>= 2.7', required: true)
 
 deps = [
-  vapoursynth_dep,
-  jansson_dep,
-  dependency('libavcodec', version : '>=58.18.0'),
-  dependency('libavformat', version : '>=58.12.0'),
+    vapoursynth_dep,
+    jansson_dep,
+    dependency('libavcodec', version: '>=58.18.0'),
+    dependency('libavformat', version: '>=58.12.0'),
 ]
 
 shared_module('bestsource', sources,
-  dependencies : deps,
-  link_with: libs,
-  install : true,
-  install_dir : join_paths(vapoursynth_dep.get_pkgconfig_variable('libdir'), 'vapoursynth'),
-  gnu_symbol_visibility : 'hidden'
+    dependencies: deps,
+    link_with: libs,
+    install: true,
+    install_dir: join_paths(vapoursynth_dep.get_pkgconfig_variable('libdir'), 'vapoursynth'),
+    gnu_symbol_visibility: 'hidden'
 )


### PR DESCRIPTION
The define P2P_SIMD has to be added to both libp2p translation units or runtime detection of CPU capabilities won't be compiled in.

I also did a small cleanup by fixing inconsistent intendation width and removing unnecessary local arguments which have already been declared globally.