### PR TITLE
Fix potential corrupted frame from hardware decoding for h264

### DIFF
--- a/src/videosource.cpp
+++ b/src/videosource.cpp
@@ -192,8 +192,12 @@ void LWVideoDecoder::OpenFile(const std::string &SourceFile, const std::string &
     }
 
     // Full explanation by more clever person available here: https://github.com/Nevcairiel/LAVFilters/issues/113
-    if (CodecContext->codec_id == AV_CODEC_ID_H264 && CodecContext->has_b_frames)
+    if (CodecContext->codec_id == AV_CODEC_ID_H264 && CodecContext->has_b_frames) {
         CodecContext->has_b_frames = 15; // the maximum possible value for h264
+
+        if (HWMode)
+            CodecContext->extra_hw_frames = 7;
+    }
 
     if (HWMode) {
         CodecContext->pix_fmt = hw_pix_fmt;


### PR DESCRIPTION
When using hardware decoding on some h264 streams, ffmpeg will print a log message like `No decoder surfaces left` or `Static surface pool size exceeded`, and the decoded frames will be either all green or corrupted. Adding a few extra hardware frames to make some decoders happy.