### PR TITLE
Add a missing header

### DIFF
--- a/src/tracklist.h
+++ b/src/tracklist.h
@@ -24,6 +24,7 @@
 #include "bsshared.h"
 #include <map>
 #include <memory>
+#include <vector>
 
 struct AVFormatContext;
 


### PR DESCRIPTION
Building Aegisub on `macos-12` with the default `Apple clang 14.0.0` compiler:

```
In file included from ../subprojects/bestsource/src/tracklist.cpp:21:
../subprojects/bestsource/src/tracklist.h:43:28: error: implicit instantiation of undefined template 'std::vector<BestTrackList::TrackInfo>'
    std::vector<TrackInfo> TrackList;
                           ^
/Applications/Xcode_14.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/iosfwd:259:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
1 error generated.
```