### PR TITLE
Pass custom options to libavformat/libavcodec

### DIFF
--- a/src/audiosource.cpp
+++ b/src/audiosource.cpp
@@ -468,7 +468,7 @@ bool BestAudioSource::IndexTrack(const ProgressFunction &Progress) {
 double BestAudioSource::GetRelativeStartTime(int Track) const {
     if (Track < 0) {
         try {
-            std::unique_ptr<LWVideoDecoder> Dec(new LWVideoDecoder(Source, "", 0, Track, true, 0, LAVFOptions));
+            std::unique_ptr<LWVideoDecoder> Dec(new LWVideoDecoder(Source, "", 0, Track, true, 0, LAVFOptions, {}, {}));
             BSVideoProperties VP;
             Dec->GetVideoProperties(VP);
             return AP.StartTime - VP.StartTime;
@@ -477,7 +477,7 @@ double BestAudioSource::GetRelativeStartTime(int Track) const {
         return 0;
     } else {
         try {
-            std::unique_ptr<LWVideoDecoder> Dec(new LWVideoDecoder(Source, "", 0, Track, true, 0, LAVFOptions));
+            std::unique_ptr<LWVideoDecoder> Dec(new LWVideoDecoder(Source, "", 0, Track, true, 0, LAVFOptions, {}, {}));
             BSVideoProperties VP;
             Dec->GetVideoProperties(VP);
             return AP.StartTime - VP.StartTime;

--- a/src/avisynth.cpp
+++ b/src/avisynth.cpp
@@ -92,7 +92,7 @@ public:
             if (StartNumber >= 0)
                 Opts["start_number"] = std::to_string(StartNumber);
 
-            V.reset(new BestVideoSource(CreateProbablyUTF8Path(Source), HWDevice ? HWDevice : "", ExtraHWFrames, Track, false, Threads, CacheMode, CachePath, &Opts));
+            V.reset(new BestVideoSource(CreateProbablyUTF8Path(Source), HWDevice ? HWDevice : "", ExtraHWFrames, Track, false, Threads, CacheMode, CachePath, &Opts, nullptr, nullptr));
 
             const BSVideoProperties &VP = V->GetVideoProperties();
             if (VP.VF.ColorFamily == cfGray) {

--- a/src/videosource.h
+++ b/src/videosource.h
@@ -109,12 +109,12 @@ private:
     AVPacket *Packet = nullptr;
     bool Seeked = false;
 
-    void OpenFile(const std::filesystem::path &SourceFile, const std::string &HWDeviceName, int ExtraHWFrames, int Track, bool VariableFormat, int Threads, const std::map<std::string, std::string> &LAVFOpts);
+    void OpenFile(const std::filesystem::path &SourceFile, const std::string &HWDeviceName, int ExtraHWFrames, int Track, bool VariableFormat, int Threads, const std::map<std::string, std::string> &LAVFOpts, const std::map<std::string, std::string> &LAVFStreamOpts, const std::map<std::string, std::string> &LAVCOpts);
     bool ReadPacket();
     bool DecodeNextFrame(bool SkipOutput = false);
     void Free();
 public:
-    LWVideoDecoder(const std::filesystem::path &SourceFile, const std::string &HWDeviceName, int ExtraHWFrames, int Track, bool VariableFormat, int Threads, const std::map<std::string, std::string> &LAVFOpts); // Positive track numbers are absolute. Negative track numbers mean nth audio track to simplify things.
+    LWVideoDecoder(const std::filesystem::path &SourceFile, const std::string &HWDeviceName, int ExtraHWFrames, int Track, bool VariableFormat, int Threads, const std::map<std::string, std::string> &LAVFOpts, const std::map<std::string, std::string> &LAVFStreamOpts, const std::map<std::string, std::string> &LAVCOpts); // Positive track numbers are absolute. Negative track numbers mean nth audio track to simplify things.
     ~LWVideoDecoder();
     [[nodiscard]] int64_t GetSourceSize() const;
     [[nodiscard]] int64_t GetSourcePostion() const;
@@ -242,6 +242,8 @@ private:
 
     static constexpr int MaxVideoSources = 4;
     std::map<std::string, std::string> LAVFOptions;
+    std::map<std::string, std::string> LAVFStreamOptions;
+    std::map<std::string, std::string> LAVCOptions;
     BSVideoProperties VP = {};
     std::filesystem::path Source;
     std::string HWDevice;
@@ -266,7 +268,7 @@ private:
     bool InitializeRFF();
     bool NearestCommonFrameRate(BSRational &FPS);
 public:
-    BestVideoSource(const std::filesystem::path &SourceFile, const std::string &HWDeviceName, int ExtraHWFrames, int Track, bool VariableFormat, int Threads, int CacheMode, const std::filesystem::path &CachePath, const std::map<std::string, std::string> *LAVFOpts, const ProgressFunction &Progress = nullptr);
+    BestVideoSource(const std::filesystem::path &SourceFile, const std::string &HWDeviceName, int ExtraHWFrames, int Track, bool VariableFormat, int Threads, int CacheMode, const std::filesystem::path &CachePath, const std::map<std::string, std::string> *LAVFOpts, const std::map<std::string, std::string> *LAVFStreamOpts, const std::map<std::string, std::string> *LAVCOpts, const ProgressFunction &Progress = nullptr);
     [[nodiscard]] int GetTrack() const; // Useful when opening nth video track to get the actual number
     void SetMaxCacheSize(size_t Bytes); /* Default max size is 1GB */
     void SetSeekPreRoll(int64_t Frames); /* The number of frames to cache before the position being fast forwarded to */


### PR DESCRIPTION
This is an incomplete PR which adds three parameters to `VideoSource`, enabling the ability for users to pass in custom options to libavformat and libavcodec.  
The new parameters are:

* `format_opts`: adds to the existing `LAVFOptions` map which is passed onto `avformat_open_input`
* `stream_opts`: passed onto `avformat_find_stream_info` for each stream
* `codec_opts`: passed onto `avcodec_open2`

Since VapourSynth doesn't support a VSMap in a VSMap, the parameters must be passed as an array of string pairs:

```Python
# like this:
format_opts = ["key1", "value1", "key2", "value2"]
# instead of what one might expect...
format_opts = {"key1": "value1", "key2": "value2"}
```

I'm mostly seeking feedback at this stage, so the following aren't done yet:

* Only implemented for VideoSource, missing for AudioSource
* Not implemented for AviSynthPlus (might not be feasible?)
* `stream_opts` and `codec_opts` are not written to the cache file (or checked on load)
* README not updated

If there's interest in this change, I can look at implementing the above.
