### PR TITLE
Treat non-subsampled XYZ tristimulus as RGB color family.

### DIFF
--- a/src/videosource.cpp
+++ b/src/videosource.cpp
@@ -55,6 +55,12 @@ static int GetColorFamily(const AVPixFmtDescriptor *Desc) {
         return 1;
     else if (Desc->flags & AV_PIX_FMT_FLAG_RGB)
         return 2;
+    else if (
+        Desc->flags & AV_PIX_FMT_FLAG_XYZ
+        && Desc->log2_chroma_h == 0
+        && Desc->log2_chroma_w == 0
+    )
+        return 2;
     else
         return 3;
 }


### PR DESCRIPTION
It's better than `ColorFamily.YUV` at conveying they are matrix-able primaries and it's what `resize` expects for transformations (e.g. to RGB primaries or Y′CbCr). `AV_PIX_FMT_FLAG_XYZ` was added in ffmpeg 7.0.

If this is better as a nested "or" condition with the prior RGB flag check, let me know and I'm happy to do it that way. I'm not C savvy.