### PR TITLE
meson: Bump required avutil version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,7 @@ endif
 deps = [
     dependency('libavcodec', version: '>=60.31.0'),
     dependency('libavformat', version: '>=60.16.0'),
-    dependency('libavutil', version: '>=58.29.0'),
+    dependency('libavutil', version: '>=58.31.0'),
     dependency('libxxhash'),
 ]
 


### PR DESCRIPTION
This is needed after 95afdcd5fc43681becdd6b9f5cfd1bbdd32b5797 . See 57c16323f26f6d726edb2fd7f83836187f058ed7 in ffmpeg for the relevant version bump.