### PR TITLE
Use PTS differences for _Duration props

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,10 +53,12 @@ if host_machine.cpu_family().startswith('x86')
     )
 endif
 
+avutil_dep = dependency('libavutil', version: '>=59.39.0')
+
 deps = [
+    avutil_dep,
     dependency('libavcodec', version: '>=61.19.0'),
     dependency('libavformat', version: '>=61.7.0'),
-    dependency('libavutil', version: '>=59.39.0'),
     dependency('libxxhash'),
 ]
 
@@ -100,7 +102,7 @@ if get_option('enable_plugin')
     endif
 
     shared_module('bestsource', plugin_sources,
-        dependencies: [bestsource_dep, vapoursynth_dep],
+        dependencies: [bestsource_dep, vapoursynth_dep, avutil_dep.partial_dependency(compile_args: true, includes: true)],
         gnu_symbol_visibility: 'hidden',
         install: true,
         install_dir: vapoursynth_dep.get_variable(pkgconfig: 'libdir') / 'vapoursynth',

--- a/src/audiosource.cpp
+++ b/src/audiosource.cpp
@@ -358,7 +358,7 @@ BestAudioFrame *BestAudioSource::Cache::GetFrame(int64_t N) {
 }
 
 BestAudioSource::BestAudioSource(const std::filesystem::path &SourceFile, int Track, int AjustDelay, int Threads, int CacheMode, const std::filesystem::path &CachePath, const std::map<std::string, std::string> *LAVFOpts, double DrcScale, const ProgressFunction &Progress)
-    : Source(SourceFile), AudioTrack(Track), DrcScale(DrcScale), Threads(Threads), FrameCache(TrackIndex) {
+    : FrameCache(TrackIndex), DrcScale(DrcScale), Source(SourceFile), AudioTrack(Track), Threads(Threads) {
     // Only make file path absolute if it exists to pass through special protocol paths
     std::error_code ec;
     if (std::filesystem::exists(SourceFile, ec))

--- a/src/avisynth.cpp
+++ b/src/avisynth.cpp
@@ -255,10 +255,9 @@ public:
             Env->ThrowError("BestVideoSource: %s", e.what());
         }
 
-        const BSVideoProperties &VP = V->GetVideoProperties();
         AVSMap *Props = Env->getFramePropsRW(Dst);
 
-        SetSynthFrameProperties(Src, VP, RFF, V->GetFrameIsTFF(n, RFF),
+        SetSynthFrameProperties(n, Src, *V, RFF, V->GetFrameIsTFF(n, RFF),
             [Props, Env](const char *Name, int64_t V) { Env->propSetInt(Props, Name, V, 1); },
             [Props, Env](const char *Name, double V) { Env->propSetFloat(Props, Name, V, 1); },
             [Props, Env](const char *Name, const char *V, int Size, bool Utf8) { Env->propSetData(Props, Name, V, Size, 1); });

--- a/src/synthshared.h
+++ b/src/synthshared.h
@@ -26,6 +26,6 @@
 #include <functional>
 #include <cstdint>
 
-void SetSynthFrameProperties(const std::unique_ptr<BestVideoFrame> &Src, const BSVideoProperties &VP, bool RFF, bool TFF, const std::function<void(const char *, int64_t)> &mapSetInt, const std::function<void(const char *, double)> &mapSetFloat, const std::function<void(const char *, const char *, int, bool)> &mapSetData);
+void SetSynthFrameProperties(int n, const std::unique_ptr<BestVideoFrame> &Src, const BestVideoSource &VS, bool RFF, bool TFF, const std::function<void(const char *, int64_t)> &mapSetInt, const std::function<void(const char *, double)> &mapSetFloat, const std::function<void(const char *, const char *, int, bool)> &mapSetData);
 
 #endif

--- a/src/vapoursynth.cpp
+++ b/src/vapoursynth.cpp
@@ -108,12 +108,11 @@ static const VSFrame *VS_CC BestVideoSourceGetFrame(int n, int ActivationReason,
             return nullptr;
         }
 
-        const BSVideoProperties &VP = D->V->GetVideoProperties();
         VSMap *Props = vsapi->getFramePropertiesRW(Dst);
         if (AlphaDst)
             vsapi->mapConsumeFrame(Props, "_Alpha", AlphaDst, maAppend);
 
-        SetSynthFrameProperties(Src, VP, D->RFF, D->V->GetFrameIsTFF(n, D->RFF),
+        SetSynthFrameProperties(n, Src, *D->V, D->RFF, D->V->GetFrameIsTFF(n, D->RFF),
             [Props, vsapi](const char *Name, int64_t V) { vsapi->mapSetInt(Props, Name, V, maAppend); },
             [Props, vsapi](const char *Name, double V) { vsapi->mapSetFloat(Props, Name, V, maAppend); },
             [Props, vsapi](const char *Name, const char *V, int Size, bool Utf8) { vsapi->mapSetData(Props, Name, V, Size, Utf8 ? dtUtf8 : dtBinary, maAppend); });


### PR DESCRIPTION
frame->duration is often just computed from the track-wide frame rate and hence unreliable.

For the last frame, where no following PTS is available, the logic just matches the previous frames's duration. In theory the track's duration could be referenced instead, but the current logic matches FFMS2.