### PR TITLE
Make BestSourceException and derivatives visible to linked modules.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,9 @@ if meson.get_compiler('cpp').get_linker_id() in ['ld.bfd', 'ld.gold', 'ld.mold']
     link_args += ['-Wl,-Bsymbolic']
 endif
 
-if get_option('default_library') != 'static'
+if get_option('default_library') == 'static'
+    api_args += ['-DBSSHARED_API_STATIC']
+else
     api_args += ['-DBSSHARED_API_BUILDING']
 endif
 

--- a/src/bsshared.h
+++ b/src/bsshared.h
@@ -28,10 +28,10 @@
 #include <functional>
 #include <filesystem>
 
-#if (defined(_WIN32) || defined(__CYGWIN__))
+#if (defined(_WIN32) || defined(__CYGWIN__)) && !defined(BSSHARED_API_STATIC)
 #  define BSSHARED_API_EXPORT __declspec(dllexport)
 #  define BSSHARED_API_IMPORT __declspec(dllimport)
-#elif defined(__OS2__)
+#elif defined(__OS2__) && !defined(BSSHARED_API_STATIC)
 #  define BSSHARED_API_EXPORT __declspec(dllexport)
 #  define BSSHARED_API_IMPORT
 #elif __GNUC__ >= 4


### PR DESCRIPTION
Keeping these hidden can cause the VapourSynth plugin to try to catch a made-up version of the exception classes instead of the ones actually used by libbestsource. See https://gcc.gnu.org/wiki/Visibility#Problems_with_C.2B-.2B-_exceptions_.28please_read.21.29

Fixes vapoursynth/bestsource#114.