### PR TITLE
Get rid of VS submodule part 2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "AviSynthPlus"]
 	path = AviSynthPlus
 	url = https://github.com/AviSynth/AviSynthPlus.git
-[submodule "vapoursynth"]
-	path = vapoursynth
-	url = https://github.com/vapoursynth/vapoursynth.git

--- a/meson.build
+++ b/meson.build
@@ -67,14 +67,31 @@ if meson.get_compiler('cpp').get_linker_id() in ['ld.bfd', 'ld.gold', 'ld.mold']
     link_args += '-Wl,-Bsymbolic'
 endif
 
+bestsource_lib_args = {}
+if enable_plugin
+    incdir = include_directories(
+        run_command(
+            find_program('python', 'python3'),
+            '-c',
+            'import vapoursynth as vs; print(vs.get_include())',
+            check: true,
+        ).stdout().strip(),
+        'AviSynthPlus/avs_core/include'
+    )
+
+    bestsource_lib_args = {
+        'include_directories': incdir,
+        'install_dir': py.get_install_dir() / 'vapoursynth/plugins'
+    }
+endif
+
 bestsource = library('bestsource',
     sources,
     dependencies: deps,
-    include_directories: include_directories('vapoursynth/include', 'AviSynthPlus/avs_core/include'),
     install: true,
-    install_dir: enable_plugin ? py.get_install_dir() / 'vapoursynth/plugins' : get_option('libdir'),
     link_args: link_args,
     link_with: libs,
+    kwargs: bestsource_lib_args
 )
 
 if not enable_plugin


### PR DESCRIPTION
c47a8413d4983fad7c7169c8935eb275edf1ed63 removed the vapoursynth from the submodule, but it has been reverted in 88ab59d18f98e4b3c8f5bd867d9f86483e37770e due to this issue https://github.com/vapoursynth/bestsource/issues/129

This approach allow to remove vapoursynth from the submodule and dont require it's installation when enable_plugin is disabled