### PR TITLE
meson: Add meson.override_dependency for bestsource

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -88,3 +88,4 @@ bestsource_dep = declare_dependency(
     include_directories: include_directories('src'),
     link_with: bestsource,
 )
+meson.override_dependency('bestsource', bestsource_dep)


### PR DESCRIPTION
Register bestsource_dep via meson.override_dependency() so projects that pull in bestsource as a meson subproject can do dependency('bestsource', fallback: ...) without needing to know the internal variable name (bestsource_dep).
The wrapdb documentation (https://mesonbuild.com/Adding-new-projects-to-wrapdb.html#creating-the-wrap-contents) says:  it is strongly advised in such cases to request that the upstream repository use meson.override_dependency